### PR TITLE
gradle: include google() repo for android plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'


### PR DESCRIPTION
Fixes: Could not find com.android.tools.build:gradle:3.0.0.

Since version 3.0 the android gradle plugin is only available inside the google() repo, not in jcenter() anymore. Fixes the build for fdroid, when you release a new version: 

https://f-droid.org/wiki/page/com.brentpanther.litecoinwidget/lastbuild_20