### PR TITLE
Minor HTTP improvements

### DIFF
--- a/bitcoin/src/main/java/com/brentpanther/bitcoinwidget/exchange/ExchangeHelper.kt
+++ b/bitcoin/src/main/java/com/brentpanther/bitcoinwidget/exchange/ExchangeHelper.kt
@@ -27,7 +27,17 @@ internal object ExchangeHelper {
                     CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA)
             .build()
 
-    val connectionPool = ConnectionPool()
+    private val client: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .connectionSpecs(listOf(SPEC, ConnectionSpec.CLEARTEXT))
+            .retryOnConnectionFailure(false)
+            .connectionPool(ConnectionPool())
+            .hostnameVerifier { _, _ -> true }.build()
+    }
 
     @Throws(IOException::class)
     @JvmOverloads
@@ -45,15 +55,6 @@ internal object ExchangeHelper {
     private fun getString(url: String, headers: Headers? = null) = get(url, headers).body!!.string()
 
     private fun get(url: String, headers: Headers? = null): Response {
-        val client = OkHttpClient.Builder()
-            .followRedirects(true)
-            .followSslRedirects(true)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .connectionSpecs(listOf(SPEC, ConnectionSpec.CLEARTEXT))
-            .retryOnConnectionFailure(false)
-            .connectionPool(connectionPool)
-            .hostnameVerifier { _, _ -> true }.build()
         var builder: Request.Builder = Request.Builder().url(url)
         headers?.let {
             builder = builder.headers(it)


### PR DESCRIPTION
Hello,

some exchanges only provide one price ticker for all coins. When there are multiple widgets configured with such source, identical requests are made when widgets are refreshed (I'm watching 8 coins on Bitpanda :slightly_smiling_face: ) . So, HTTP caching should reduce the number of duplicate requests, update should be faster and consume less data.

When I was looking at this I went through OkHttpClient docs, and there is this [OkHttpClients Should Be Shared](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#okhttpclients-should-be-shared) paragraph. So I had first extracted the client from `get` function and made it shared, in the first commit in this PR. Seems to work fine.

The 2nd commit enables caching in the client. The response interceptor sets `Cache-Control` header in responses from exchanges that return price ticker for all pairs to ensure they are cached (but for a very short `max-age` in order that it does not prevent manual or forced refresh). For responses from other exchanges, it sets `no-cache no-store` cache control to avoid caching.
