### PR TITLE
exchange: Fix values format for coinmate ticker

### DIFF
--- a/bitcoin/src/main/java/com/brentpanther/bitcoinwidget/exchange/Exchange.kt
+++ b/bitcoin/src/main/java/com/brentpanther/bitcoinwidget/exchange/Exchange.kt
@@ -349,7 +349,7 @@ enum class Exchange(val exchangeName: String, shortName: String? = null) {
 
         override fun getValue(coin: String, currency: String, priceType: PriceType): String? {
             val url = "https://coinmate.io/api/ticker?currencyPair=${coin}_$currency"
-            val data = getJsonObject(url)
+            val data = getJsonObject(url)["data"]?.jsonObject ?: return null
             return when (priceType) {
                 SPOT -> data["last"]
                 BID -> data["bid"]


### PR DESCRIPTION
Fix #146 

Coinmate returns json in this format:
```json
{
  "error": false,
  "errorMessage": null,
  "data": {
    "last": 2365435,
    "high": 2384505,
    "low": 2351514,
    "amount": 8.78068793,
    "bid": 2365428,
    "ask": 2367038,
    "change": -0.42801764,
    "open": 2375603,
    "timestamp": 1749634952,
    "status": "TRADING"
  }
}
```

so the `["data"]` attribute must be parsed from the response.

Please double check my proposed patch as I am not skilled in Kotlin and I wasn't able to build it. I hope this helps and thanks :pray: 